### PR TITLE
fix Django 1.4 compatibility issue

### DIFF
--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -1,7 +1,9 @@
 import logging
+import inspect
 
 from django.db.models import get_model, ObjectDoesNotExist
 from django.contrib.admin.widgets import AdminFileWidget, ForeignKeyRawIdWidget
+from django.contrib.admin.sites import site
 from django.conf import settings
 
 from easy_thumbnails.files import get_thumbnailer
@@ -55,6 +57,8 @@ class ImageCropWidget(AdminFileWidget, CropWidget):
 class CropForeignKeyWidget(ForeignKeyRawIdWidget, CropWidget):
     def __init__(self, *args, **kwargs):
         self.field_name = kwargs.pop('field_name')
+        if 'admin_site' in inspect.getargspec(ForeignKeyRawIdWidget.__init__)[0]:  # Django 1.4
+            kwargs['admin_site'] = site
         super(CropForeignKeyWidget, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None):


### PR DESCRIPTION
```
Django Version: 1.4
Exception Type:  TypeError
Exception Value: __init__() takes at least 3 arguments (3 given)
Exception Location: /image_cropping/widgets.py in __init__, line 60
    super(CropForeignKeyWidget, self).__init__(*args, **kwargs)
```

The signature for `ForeignKeyRawIdWidget.__init__()` in Django 1.4 is:

``` python
class ForeignKeyRawIdWidget(forms.TextInput):
    def __init__(self, rel, admin_site, attrs=None, using=None):
```

The required argument `admin_site` is new to Django 1.4. The `formfield` method of `CropForeignKey` in fields.py doesn't include the `admin_site` argument:

``` python
def formfield(self, *args, **kwargs):
    kwargs['widget'] = CropForeignKeyWidget(self.rel, field_name=self.field_name,
        using=kwargs.get('using'))
    return super(CropForeignKey, self).formfield(*args, **kwargs)
```

This patch inspects the arguments of `ForeignKeyRawIdWidget.__init__()` to see if `admin_site` is a required argument and patches it into the `__init__` kwargs for `CropForeignKeyWidget`. If admin_site is required it uses django.contrib.admin.sites.site as the value.

``` python
class CropForeignKeyWidget(ForeignKeyRawIdWidget, CropWidget):
    def __init__(self, *args, **kwargs):
        if 'admin_site' in inspect.getargspec(ForeignKeyRawIdWidget.__init__)[0]:  # Django 1.4
            kwargs['admin_site'] = site
        self.field_name = kwargs.pop('field_name')
        super(CropForeignKeyWidget, self).__init__(*args, **kwargs)
```

Could be argued whether this belongs in the Widget init or the CropForeignKey formfield.
