### PR TITLE
Fix to remove image_cropping jQuery variable from global javascript namespace

### DIFF
--- a/image_cropping/static/image_cropping/image_cropping.js
+++ b/image_cropping/static/image_cropping/image_cropping.js
@@ -1,5 +1,5 @@
 var image_cropping = {
-  $: jQuery.noConflict(),
+  $: jQuery.noConflict(true),
   init: function() {
     // set styles for size-warning
     var style_img_warning = 'div.jcrop-image.size-warning .jcrop-vline{border:1px solid red; background: none;}' +


### PR DESCRIPTION
The $ variable was removed with jQuery.noConflict(), but that left the jQuery variable still hanging around.  This fixes that by adding "true" as a parameter to noConflict, which also removes the jQuery variable.

Before:
After the page loaded, $.fn.jquery returned the version of my custom jQuery, but jQuery.fn.jquery returned the version of image_cropping's jquery.

Now:
After the page loads, both $.fn.jquery and jQuery.fn.jquery return the version of my custom jQuery.
