### PR TITLE
Issue #38: cropped_thumbnail template tag fix

### DIFF
--- a/image_cropping/templatetags/cropping.py
+++ b/image_cropping/templatetags/cropping.py
@@ -17,15 +17,15 @@ def cropped_thumbnail(parser, token):
         raise template.TemplateSyntaxError("%r tag requires at least two arguments" % args[0])
 
     option = None
-    upscale = False
     detail = False
-
+    upscale = False
+    
     instance = args[1]
     # strip quotes from ratio field
     ratiofieldname = args[2].strip('"\'')
 
     # parse additional arguments
-    for arg in args[4:]:
+    for arg in args[3:]:
         arg = arg.lower()
         try:
             name, value = arg.split('=')
@@ -57,7 +57,7 @@ def cropped_thumbnail(parser, token):
             else:
                 raise template.TemplateSyntaxError("%s is an invalid option" % arg)
 
-    return CroppingNode(instance, ratiofieldname, option, upscale)
+    return CroppingNode(instance, ratiofieldname, option, detail, upscale)
 
 
 class CroppingNode(template.Node):

--- a/image_cropping/templatetags/cropping.py
+++ b/image_cropping/templatetags/cropping.py
@@ -8,7 +8,7 @@ register = template.Library()
 def cropped_thumbnail(parser, token):
     '''
     Syntax:
-    {% cropped_thumbnail instancename ratiofieldname [scale=0.1|width=100|height=200] [upscale] %}
+    {% cropped_thumbnail instancename ratiofieldname [scale=0.1|width=100|height=200] [detail] [upscale] %}
     '''
     args = token.split_contents()
 
@@ -18,13 +18,14 @@ def cropped_thumbnail(parser, token):
 
     option = None
     upscale = False
+    detail = False
 
     instance = args[1]
     # strip quotes from ratio field
     ratiofieldname = args[2].strip('"\'')
 
     # parse additional arguments
-    for arg in args[3:]:
+    for arg in args[4:]:
         arg = arg.lower()
         try:
             name, value = arg.split('=')
@@ -51,6 +52,8 @@ def cropped_thumbnail(parser, token):
         except ValueError:  # check for upscale argument
             if arg == 'upscale':
                 upscale = True
+            elif arg == 'detail':
+                detail = True
             else:
                 raise template.TemplateSyntaxError("%s is an invalid option" % arg)
 
@@ -58,10 +61,11 @@ def cropped_thumbnail(parser, token):
 
 
 class CroppingNode(template.Node):
-    def __init__(self, instance, ratiofieldname, option=None, upscale=False):
+    def __init__(self, instance, ratiofieldname, option=None, detail=False, upscale=False):
         self.instance = instance
         self.ratiofieldname = ratiofieldname
         self.option = option
+        self.detail = detail
         self.upscale = upscale
 
     def render(self, context):
@@ -124,7 +128,7 @@ class CroppingNode(template.Node):
             'size': size,
             'box': box,
             'crop': True,
-            'detail': True,
+            'detail': self.detail,
             'upscale': self.upscale
         }
         return thumbnailer.get_thumbnail(thumbnail_options).url


### PR DESCRIPTION
Making the "detail" argument optional and setting it to "False" by default to fix upscaling problem and offer more flexibility.