### PR TITLE
Don't try to thumbnail images that don't exist

### DIFF
--- a/example/tests/test_initialcropping.py
+++ b/example/tests/test_initialcropping.py
@@ -7,7 +7,7 @@ from image_cropping.utils import max_cropping
 from ..models import Image, ImageFK
 
 
-class TemplateTagTestCase(TestCase):
+class InitialCroppingTestCase(TestCase):
     def setUp(self):
         self.path = '%s%s' % (settings.STATIC_ROOT, "/images/example_image.jpg")
         self.width = 400

--- a/example/tests/test_templatetag.py
+++ b/example/tests/test_templatetag.py
@@ -56,3 +56,8 @@ class TemplateTagTestCase(TestCase):
         self._test_free_cropping({'max_size': '200x200'})
         self.assertTrue(
             '200x200' in self._test_free_cropping({'max_size': '200x200'}))
+
+    def test_missing_image(self):
+        # Simply testing that no error is thrown when the image isn't set.
+        self.image.image_field = ''
+        self._test_free_cropping()

--- a/image_cropping/templatetags/cropping.py
+++ b/image_cropping/templatetags/cropping.py
@@ -75,8 +75,9 @@ class CroppingNode(template.Node):
         if ratiofield.image_fk_field:  # image is ForeignKey
             # get the imagefield
             image = getattr(image, ratiofield.image_fk_field)
-            if not image:
-                return
+
+        if not image:
+            return
 
         box = getattr(instance, self.ratiofieldname)
         if ratiofield.free_crop:


### PR DESCRIPTION
Ideally this would be addressed by adopting the `default` option available in the `easy_thumbnails` `thumbnail` tag. For now, this at least prevents errors being thrown when thumbnailing images that don't exist.

Also re-named one of the test classes to avoid a naming conflict (the template tag tests weren't being run because the test runner was ignoring the other test class with the same name).
