### PR TITLE
Remove IO error in admin if image doesn't exist

### DIFF
--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -47,7 +47,7 @@ def get_attrs(image, name):
             'data-org-width': width,
             'data-org-height': height,
         }
-    except (ValueError, AttributeError):
+    except (ValueError, AttributeError, IOError):
         # can't create thumbnail from image
         return {}
 


### PR DESCRIPTION
Hi there,

Not sure what you think about this one.  It simply fixes the admin IO error you receive if you visit an admin page containing an image/cropping field where the image has been added but the physical image doesn't exist (ie you're working locally with a copy of the live database but don't have all the media files locally)

It also means that users can fix broken image paths becuase they can still access the admin page even if the image no longer exists.
