### PR TITLE
Support Jcrop.setImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ media/
 .coverage/
 coverage
 settings_local.py
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -280,6 +280,8 @@ of javascript:
         jcrop[widget_name].setImage(reader.result);
     };
 
+to handle image input values changes.
+
 To preserve size constraints on the image you will also have to provide ``box_max_width`` and/or ``box_max_height``
 to ``ImageRatioField`` fields on your models.
 

--- a/README.rst
+++ b/README.rst
@@ -266,6 +266,23 @@ By default the image cropping widget embeds a recent version of jQuery.
 You can point to another version using the ``IMAGE_CROPPING_JQUERY_URL`` setting, though compatibility
 issues may arise if your jQuery version differs from the one that is tested against.
 
+You can also set ``IMAGE_CROPPING_JQUERY_URL`` to ``None`` to disable inclusion of jQuery by the widget.
+
+
+Jcrop setImage
+--------------
+
+Widget supports dynamic changes of the source image by use of FileReader, but you do need to add a piece
+of javascript:
+
+    reader  = new FileReader();
+    reader.onloadend = function () {
+        jcrop[widget_name].setImage(reader.result);
+    };
+
+To preserve size constraints on the image you will also have to provide ``box_max_width`` and/or ``box_max_height``
+to ``ImageRatioField`` fields on your models.
+
 
 Changelog
 =========

--- a/image_cropping/fields.py
+++ b/image_cropping/fields.py
@@ -29,7 +29,7 @@ class ImageRatioField(models.CharField):
                  adapt_rotation=False, allow_fullsize=False, verbose_name=None,
                  help_text=None, hide_image_field=False,
                  size_warning=settings.IMAGE_CROPPING_SIZE_WARNING,
-                 box_max_width=None, box_max_height=None):
+                 box_max_width='', box_max_height=''):
         if '__' in image_field:
             self.image_field, self.image_fk_field = image_field.split('__')
         else:

--- a/image_cropping/fields.py
+++ b/image_cropping/fields.py
@@ -28,7 +28,8 @@ class ImageRatioField(models.CharField):
     def __init__(self, image_field, size='0x0', free_crop=False,
                  adapt_rotation=False, allow_fullsize=False, verbose_name=None,
                  help_text=None, hide_image_field=False,
-                 size_warning=settings.IMAGE_CROPPING_SIZE_WARNING):
+                 size_warning=settings.IMAGE_CROPPING_SIZE_WARNING,
+                 box_max_width=None, box_max_height=None):
         if '__' in image_field:
             self.image_field, self.image_fk_field = image_field.split('__')
         else:
@@ -40,6 +41,8 @@ class ImageRatioField(models.CharField):
         self.allow_fullsize = allow_fullsize
         self.size_warning = size_warning
         self.hide_image_field = hide_image_field
+        self.box_max_width = box_max_width
+        self.box_max_height = box_max_height
         field_kwargs = {
             'max_length': 255,
             'default': '',
@@ -68,6 +71,8 @@ class ImageRatioField(models.CharField):
             'help_text': self.help_text,
             'hide_image_field': self.hide_image_field,
             'size_warning': self.size_warning,
+            'box_max_width': self.box_max_width,
+            'box_max_height': self.box_max_height,
         }
         return self.name, 'image_cropping.fields.ImageRatioField', args, kwargs
 
@@ -118,6 +123,8 @@ class ImageRatioField(models.CharField):
         kwargs['widget'] = forms.TextInput(attrs={
             'data-min-width': self.width,
             'data-min-height': self.height,
+            'data-box_max_width': self.box_max_width,
+            'data-box_max_height': self.box_max_height,
             'data-ratio': ratio,
             'data-image-field': self.image_field,
             'data-my-name': self.name,

--- a/image_cropping/static/image_cropping/image_cropping.js
+++ b/image_cropping/static/image_cropping/image_cropping.js
@@ -1,3 +1,5 @@
+var jcrop = {};
+
 var image_cropping = function ($) {
 
     function init() {
@@ -78,8 +80,6 @@ var image_cropping = function ($) {
 
         // hide the input field, show image to crop instead
         $this.hide().after($image);
-
-        var jcrop = {};
 
         $('#' + image_id).Jcrop(options, function(){jcrop[image_id]=this;});
 

--- a/image_cropping/static/image_cropping/image_cropping.js
+++ b/image_cropping/static/image_cropping/image_cropping.js
@@ -1,4 +1,4 @@
-var jcrop = {};
+window.jcrop = {};
 
 var image_cropping = function ($) {
 
@@ -87,11 +87,11 @@ var image_cropping = function ($) {
         // hide the input field, show image to crop instead
         $this.hide().after($image);
 
-        $('#' + image_id).Jcrop(options, function(){jcrop[image_id]=this;});
+        $('#' + image_id).Jcrop(options, function(){window.jcrop[image_id]=this;});
 
         if ($this.data('allow-fullsize') === true) {
           if(cropping_disabled){
-            jcrop[image_id].release();
+            window.jcrop[image_id].release();
             $this.val('-'+$this.val());
           }
           var label = 'allow-fullsize-'+image_id;
@@ -108,11 +108,11 @@ var image_cropping = function ($) {
           $('#'+label).click(function(){
             if (cropping_disabled === true){
               $this.val($this.val().substr(1));
-              jcrop[image_id].setSelect($this.val().split(','));
+              window.jcrop[image_id].setSelect($this.val().split(','));
               cropping_disabled = false;
             } else {
               $this.val('-'+$this.val());
-              jcrop[image_id].release();
+              window.jcrop[image_id].release();
               cropping_disabled = true;
             }
           });

--- a/image_cropping/static/image_cropping/image_cropping.js
+++ b/image_cropping/static/image_cropping/image_cropping.js
@@ -56,6 +56,12 @@ var image_cropping = function ($) {
         if ($this.data('ratio')) {
           options['aspectRatio'] = $this.data('ratio');
         }
+        if ($this.data('box_max_width')) {
+          options['boxWidth'] = $this.data('box_max_width');
+        }
+        if ($this.data('box_max_height')) {
+          options['boxHeight'] = $this.data('box_max_height');
+        }
 
         var cropping_disabled = false;
         if($this.val()[0] == "-"){

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -53,13 +53,17 @@ def get_attrs(image, name):
 
 class CropWidget(object):
     class Media:
-        js = (,)
         if settings.IMAGE_CROPPING_JQUERY_URL:
-            js += (settings.IMAGE_CROPPING_JQUERY_URL,)
-        js += (
-            "image_cropping/js/jquery.Jcrop.min.js",
-            "image_cropping/image_cropping.js",
-        )
+            js = (
+                settings.IMAGE_CROPPING_JQUERY_URL,
+                "image_cropping/js/jquery.Jcrop.min.js",
+                "image_cropping/image_cropping.js",
+            )
+        else:
+            js = (
+                "image_cropping/js/jquery.Jcrop.min.js",
+                "image_cropping/image_cropping.js",
+            )
         css = {'all': ("image_cropping/css/jquery.Jcrop.min.css",
                        "image_cropping/css/image_cropping.css",)}
 

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -50,7 +50,16 @@ def get_attrs(image, name):
         }
     except (ValueError, AttributeError, IOError):
         # can't create thumbnail from image
-        return {}
+        # thumbnail not necessarry but some stub default values useful to keep the js code ok
+        return {
+            'class': "crop-thumb",
+            'data-thumbnail-url': '',
+            'data-field-name': name,
+            'data-org-width': 0,
+            'data-org-height': 0,
+            'data-max-width': 300,
+            'data-max-height': 300,
+        }
 
 
 class CropWidget(object):
@@ -74,8 +83,9 @@ class ImageCropWidget(AdminFileWidget, CropWidget):
     def render(self, name, value, attrs=None):
         if not attrs:
             attrs = {}
-        if value:
-            attrs.update(get_attrs(value, name))
+        # if value:
+        # get_attrs will return defaults when value is none
+        attrs.update(get_attrs(value, name))
         return super(AdminFileWidget, self).render(name, value, attrs)
 
 

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -53,8 +53,10 @@ def get_attrs(image, name):
 
 class CropWidget(object):
     class Media:
-        js = (
-            settings.IMAGE_CROPPING_JQUERY_URL,
+        js = (,)
+        if settings.IMAGE_CROPPING_JQUERY_URL:
+            js += (settings.IMAGE_CROPPING_JQUERY_URL,)
+        js += (
             "image_cropping/js/jquery.Jcrop.min.js",
             "image_cropping/image_cropping.js",
         )

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -45,6 +45,8 @@ def get_attrs(image, name):
             'data-field-name': name,
             'data-org-width': width,
             'data-org-height': height,
+            'data-max-width': width,
+            'data-max-height': height,
         }
     except (ValueError, AttributeError, IOError):
         # can't create thumbnail from image


### PR DESCRIPTION
Hi jonasundderwolf.

Great piece of code you have there, bravo and many thanks for your work.
Perhaps you'd be interested in my fork? Changelog: 
- move jcrop variable to global scope -- allows access to Jcrop api;
- add Jcrop.options.boxWidth and Jcrop.options.boxHeight support through model field -- lets us define a maximum allowed space for the cropping widget when source image is changed through Jcrop.setImage;
- IMAGE_CROPPING_JQUERY_URL = None -- prevents inclusion second jQuery copy when, for example, it's used in frontend and jQuery has already been loaded.

Updated doc to reflect these.

Again, thank you for your work, you're great.

Cheers,
Peter