### PR TITLE
Fix for Exception if file for ImageField not found

### DIFF
--- a/image_cropping/fields.py
+++ b/image_cropping/fields.py
@@ -106,10 +106,16 @@ class ImageRatioField(models.CharField):
                 continue
 
             # calculate initial cropping
-            box = max_cropping(ratiofield.width, ratiofield.height,
-                               image.width, image.height,
-                               free_crop=ratiofield.free_crop)
-            box = ','.join(map(lambda i: str(i), box))
+            try:
+                # catch exceptions connected with corrupted image
+                # ex. in case filesystem corruption, accidentaly removed file, or file on CDN is not ready
+                # if image is not valid do not blow up webpage with 500, but still let user to save adminmodel 
+                box = max_cropping(ratiofield.width, ratiofield.height,
+                                   image.width, image.height,
+                                   free_crop=ratiofield.free_crop)
+                box = ','.join(map(lambda i: str(i), box))
+            except IOError:
+                box = ''
             setattr(instance, ratiofieldname, box)
 
     def formfield(self, *args, **kwargs):

--- a/image_cropping/templatetags/cropping.py
+++ b/image_cropping/templatetags/cropping.py
@@ -1,5 +1,6 @@
 from django import template
 from easy_thumbnails.files import get_thumbnailer
+from easy_thumbnails.exceptions import InvalidImageFormatError
 
 register = template.Library()
 VALID_OPTIONS = ('scale', 'width', 'height', 'max_size')
@@ -86,4 +87,11 @@ def cropped_thumbnail(context, instance, ratiofieldname, **kwargs):
     # pass remaining arguments to easy_thumbnail
     thumbnail_options.update(kwargs)
 
-    return thumbnailer.get_thumbnail(thumbnail_options).url
+    # catch exceptions connected with corrupted image
+    # ex. in case filesystem corruption, accidentaly removed file, or file on CDN is not ready
+    # if image is not valid do not blow up webpage with 500, but simply do not show it, 
+    try:
+        url = thumbnailer.get_thumbnail(thumbnail_options).url
+    except InvalidImageFormatError:
+        url = ''
+    return url


### PR DESCRIPTION
Fix for situation if one of Django model Imege Fields is corrupted or not present in filesystem. With this patch user will be still able to save Object in admin page, and front pages will not raise 500 if one of images is not available any more.