### PR TITLE
Fix tests with Django 1.9

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -3,5 +3,5 @@ easy_thumbnails==2.2
 pyvirtualdisplay==0.1.5
 selenium==2.45
 WebTest==2.0.18
-django-webtest==1.7.7
+django-webtest==1.7.8
 coverage==3.7.1


### PR DESCRIPTION
django-webtest added Django 1.9 compatibility with version 1.7.8.

All tests pass with Django 1.9 and python 3.5.