### PR TITLE
Isolating dependency of easy_thumbnails as a swappable backend. Adding suport for django-filebrowser

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,7 +1,7 @@
 django==1.9
 easy_thumbnails==2.3
-pyvirtualdisplay==0.1.5
-selenium==2.48
+PyVirtualDisplay==0.2
+selenium==2.53.1
 WebTest==2.0.20
 django-webtest==1.7.8
 coverage==3.7.1

--- a/example/views.py
+++ b/example/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect
 from django.core.urlresolvers import reverse
-from easy_thumbnails.files import get_thumbnailer
+from image_cropping.utils import get_backend
 from .models import Image, ImageFK
 from .forms import ImageForm
 
@@ -30,12 +30,12 @@ def thumbnail_foreign_key(request, instance_id=None):
 
 def show_thumbnail(request, image_id):
     image = get_object_or_404(Image, pk=image_id)
-    thumbnail_url = get_thumbnailer(image.image_field).get_thumbnail({
+    thumbnail_url = get_backend().get_thumbnail_url(image.image_field, {
         'size': (430, 360),
         'box': image.cropping,
         'crop': True,
         'detail': True,
-    }).url
+    })
     return render(request, 'thumbnail.html', {'thumbnail_url': thumbnail_url})
 
 

--- a/image_cropping/admin.py
+++ b/image_cropping/admin.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from . import widgets
+from .utils import get_backend
 
 
 class ImageCroppingMixin(object):
@@ -7,18 +7,6 @@ class ImageCroppingMixin(object):
         crop_fields = getattr(self.model, 'crop_fields', {})
         if db_field.name in crop_fields:
             target = crop_fields[db_field.name]
-            if target['fk_field']:
-                # it's a ForeignKey
-                kwargs['widget'] = widgets.CropForeignKeyWidget(
-                    db_field.rel,
-                    field_name=target['fk_field'],
-                    admin_site=self.admin_site,
-                )
-            elif target['hidden']:
-                # it's a hidden ImageField
-                kwargs['widget'] = widgets.HiddenImageCropWidget
-            else:
-                # it's a regular ImageField
-                kwargs['widget'] = widgets.ImageCropWidget
+            kwargs['widget'] = get_backend().get_widget(db_field, target, self.admin_site)
 
         return super(ImageCroppingMixin, self).formfield_for_dbfield(db_field, **kwargs)

--- a/image_cropping/backends/base.py
+++ b/image_cropping/backends/base.py
@@ -1,0 +1,19 @@
+import abc
+import six
+
+
+class ImageBackend(six.with_metaclass(abc.ABCMeta)):
+    """
+    Abstract class to expose the expected methods and properties that a custom
+    backend should provide.
+    """
+
+    exceptions_to_catch = (IOError, )
+
+    @abc.abstractmethod
+    def get_thumbnail_url(self, image_path, thumbnail_options):
+        pass
+
+    @abc.abstractmethod
+    def get_size(self, image):
+        pass

--- a/image_cropping/backends/base.py
+++ b/image_cropping/backends/base.py
@@ -21,6 +21,11 @@ class ImageBackend(six.with_metaclass(abc.ABCMeta)):
         'ImageCropField': widgets.ImageCropWidget,
     }
 
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
     @abc.abstractmethod
     def get_thumbnail_url(self, image_path, thumbnail_options):
         pass

--- a/image_cropping/backends/easy_thumbs.py
+++ b/image_cropping/backends/easy_thumbs.py
@@ -1,6 +1,8 @@
 """
-Backend for "easy_thumbnails" package. This module can't be named
+Backend for easy_thumbnails_ package. This module can't be named
 "easy_thumbnails" in order to avoid Python import conflicts.
+
+.. _easy_thumbnails: https://github.com/SmileyChris/easy-thumbnails
 """
 
 from .base import ImageBackend

--- a/image_cropping/backends/easy_thumbs.py
+++ b/image_cropping/backends/easy_thumbs.py
@@ -1,0 +1,21 @@
+"""
+Backend for "easy_thumbnails" package. This module can't be named
+"easy_thumbnails" in order to avoid Python import conflicts.
+"""
+
+from .base import ImageBackend
+
+from easy_thumbnails.files import get_thumbnailer
+from easy_thumbnails.source_generators import pil_image
+from easy_thumbnails.exceptions import InvalidImageFormatError
+
+
+class EasyThumbnailsBackend(ImageBackend):
+    exceptions_to_catch = (InvalidImageFormatError, IOError)
+
+    def get_thumbnail_url(self, image_path, thumbnail_options):
+        thumb = get_thumbnailer(image_path)
+        return thumb.get_thumbnail(thumbnail_options).url
+
+    def get_size(self, image):
+        return pil_image(image).size

--- a/image_cropping/backends/fb.py
+++ b/image_cropping/backends/fb.py
@@ -1,0 +1,38 @@
+"""
+Backend for filebrowser_ package. This module can't be named
+"filebrowser" in order to avoid Python import conflicts.
+
+.. _filebrowser: https://github.com/sehmaschine/django-filebrowser
+"""
+
+from filebrowser.base import FileObject
+from filebrowser.fields import FileBrowseWidget
+
+from ..widgets import CropWidget, get_attrs
+from .base import ImageBackend
+
+
+class CropFileBrowseWidget(FileBrowseWidget, CropWidget):
+    def render(self, name, value, attrs=None):
+        if not attrs:
+            attrs = {}
+        if value:
+            attrs.update(get_attrs(value, name))
+
+        return super(CropFileBrowseWidget, self).render(name, value, attrs)
+
+
+class FileBrowserBackend(ImageBackend):
+    # params
+    version_suffix = 'crop'
+
+    WIDGETS = dict(ImageBackend.WIDGETS)
+    WIDGETS['FileBrowseField'] = CropFileBrowseWidget
+
+    def get_thumbnail_url(self, image_path, thumbnail_options):
+        image = image_path if isinstance(image_path, FileObject) else FileObject(image_path)
+        return image.version_generate(self.version_suffix, thumbnail_options).url
+
+    def get_size(self, image):
+        image = image if isinstance(image, FileObject) else FileObject(image)
+        return image.dimensions

--- a/image_cropping/config.py
+++ b/image_cropping/config.py
@@ -7,3 +7,4 @@ class ImageCroppingAppConf(AppConf):
     THUMB_SIZE = (300, 300)
     SIZE_WARNING = False
     BACKEND = 'image_cropping.backends.easy_thumbs.EasyThumbnailsBackend'
+    BACKEND_PARAMS = {}

--- a/image_cropping/config.py
+++ b/image_cropping/config.py
@@ -6,3 +6,4 @@ class ImageCroppingAppConf(AppConf):
     JQUERY_URL = 'https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js'
     THUMB_SIZE = (300, 300)
     SIZE_WARNING = False
+    BACKEND = 'image_cropping.backends.easy_thumbs.EasyThumbnailsBackend'

--- a/image_cropping/templatetags/cropping.py
+++ b/image_cropping/templatetags/cropping.py
@@ -1,7 +1,6 @@
 from django import template
 from django.conf import settings
-from easy_thumbnails.files import get_thumbnailer
-from easy_thumbnails.exceptions import InvalidImageFormatError
+from ..utils import get_backend
 
 register = template.Library()
 VALID_OPTIONS = ('scale', 'width', 'height', 'max_size')
@@ -74,7 +73,6 @@ def cropped_thumbnail(context, instance, ratiofieldname, **kwargs):
             # box needs rotation
             size = (size[1], size[0])
 
-    thumbnailer = get_thumbnailer(image)
     thumbnail_options = {
         'size': size,
         'box': box,
@@ -89,8 +87,9 @@ def cropped_thumbnail(context, instance, ratiofieldname, **kwargs):
     thumbnail_options.update(kwargs)
 
     try:
-        url = thumbnailer.get_thumbnail(thumbnail_options).url
-    except (InvalidImageFormatError, IOError):
+        backend = get_backend()
+        url = backend.get_thumbnail_url(image, thumbnail_options)
+    except backend.exceptions_to_catch:
         # only raise an exception if THUMBNAIL_DEBUG is set to `True`
         if getattr(settings, 'THUMBNAIL_DEBUG', False):
             raise

--- a/image_cropping/utils.py
+++ b/image_cropping/utils.py
@@ -1,3 +1,10 @@
+from django.utils.module_loading import import_string
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import ugettext as _
+
+from .config import settings
+
+
 def max_cropping(width, height, image_width, image_height, free_crop=False):
     if free_crop:
         return [0, 0, image_width, image_height]
@@ -11,3 +18,14 @@ def max_cropping(width, height, image_width, image_height, free_crop=False):
     # height fits fully, width needs to be cropped
     offset = int(round((image_width - (image_height * ratio)) / 2))
     return [offset, 0, image_width - offset, image_height]
+
+
+def get_backend():
+    try:
+        cls = import_string(settings.IMAGE_CROPPING_BACKEND)
+    except ImportError as e:
+        raise ImproperlyConfigured(
+            _("Can't retrieve the image backend '{}'. Message: '{}'.").format(
+                settings.IMAGE_CROPPING_BACKEND, e))
+
+    return cls()

--- a/image_cropping/utils.py
+++ b/image_cropping/utils.py
@@ -28,4 +28,4 @@ def get_backend():
             _("Can't retrieve the image backend '{}'. Message: '{}'.").format(
                 settings.IMAGE_CROPPING_BACKEND, e))
 
-    return cls()
+    return cls(**settings.IMAGE_CROPPING_BACKEND_PARAMS)

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -7,8 +7,8 @@ from django.contrib.admin.templatetags import admin_static
 from django.db.models import ObjectDoesNotExist
 from django.contrib.admin.widgets import AdminFileWidget, ForeignKeyRawIdWidget
 
-from easy_thumbnails.source_generators import pil_image
 from .config import settings
+from .utils import get_backend
 
 try:
     # Django >= 1.9
@@ -20,16 +20,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def thumbnail(image_path):
-    from easy_thumbnails.files import get_thumbnailer
-    thumbnailer = get_thumbnailer(image_path)
+def thumbnail_url(image_path):
     thumbnail_options = {
         'detail': True,
         'upscale': True,
         'size': settings.IMAGE_CROPPING_THUMB_SIZE,
     }
-    thumb = thumbnailer.get_thumbnail(thumbnail_options)
-    return thumb
+    return get_backend().get_thumbnail_url(image_path, thumbnail_options)
 
 
 def get_attrs(image, name):
@@ -45,14 +42,14 @@ def get_attrs(image, name):
 
         try:
             # open image and rotate according to its exif.orientation
-            width, height = pil_image(image).size
+            width, height = get_backend().get_size(image)
         except AttributeError:
             # invalid image -> AttributeError
             width = image.width
             height = image.height
         return {
             'class': "crop-thumb",
-            'data-thumbnail-url': thumbnail(image).url,
+            'data-thumbnail-url': thumbnail_url(image),
             'data-field-name': name,
             'data-org-width': width,
             'data-org-height': height,

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -32,13 +32,17 @@ def thumbnail_url(image_path):
 def get_attrs(image, name):
     try:
         # TODO test case
-        # If the image file has already been closed, open it
-        if image.closed:
-            image.open()
+        try:
+            # try to use image as a file
+            # If the image file has already been closed, open it
+            if image.closed:
+                image.open()
 
-        # Seek to the beginning of the file.  This is necessary if the
-        # image has already been read using this file handler
-        image.seek(0)
+            # Seek to the beginning of the file.  This is necessary if the
+            # image has already been read using this file handler
+            image.seek(0)
+        except:
+            pass
 
         try:
             # open image and rotate according to its exif.orientation

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email="jvp@jonasundderwolf.de",
     url="http://github.com/jonasundderwolf/django-image-cropping",
     packages=find_packages(),
-    install_requires=["django-appconf==1.0.1"],
+    install_requires=["django-appconf==1.0.1", "six"],
     include_package_data=True,
     test_suite='example.runtests.runtests',
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,11 @@ envlist = py27_django18,
 deps =
     django-appconf==1.0.1
     pillow==3
-    selenium==2.48
+    selenium==2.53.1
     WebTest==2.0.20
     django-webtest==1.7.8
     easy_thumbnails==2.3
-    pyvirtualdisplay==0.1.5
+    pyvirtualdisplay==0.2
 
 [testenv]
 commands = django-admin.py test example --liveserver=localhost:8082,8090-8100,9000-9200,7041


### PR DESCRIPTION
This PR provides suport for `django-filebrowser`, as proposed at #91.

- Isolation of all calls to `easy_thumbnails` behind a private API in the form of a `backend`.
- The backend API has a formal facade definition using an Abstract Base Class `backends.base.ImageBackend`, but this ABC is provided only to documentation purposes and explicit inheritance is not verified in favor of duck typing.

Adds a backend to allow usage with `django-filebrowser`.