### PR TITLE
Don't load jQuery if IMAGE_CROPPING_JQUERY_URL is set None or "" or "None"

### DIFF
--- a/image_cropping/static/image_cropping/image_cropping.js
+++ b/image_cropping/static/image_cropping/image_cropping.js
@@ -186,7 +186,7 @@ var image_cropping = (function ($) {
 
 jQuery(function() {
   var image_cropping_jquery_url = jQuery('.image-ratio:first').data('jquery-url');
-  if (image_cropping_jquery_url == "None") {
+  if (!image_cropping_jquery_url || image_cropping_jquery_url == "None") {
     // JQUERY_URL is set to `none`. We therefore use the existing version of
     // jQuery and leave it otherwise untouched.
     jQ = jQuery;


### PR DESCRIPTION
Many users get confused and put
IMAGE_CROPPING_JQUERY_URL = None
in their python settings and since this is translated to javascript `null` and since `null != "None"` then the script assume its loading different version of jQuery and call `noConflict(true)`.
This fix address this problem