### PR TITLE
use '-' as words separator

### DIFF
--- a/image_cropping/static/image_cropping/image_cropping.js
+++ b/image_cropping/static/image_cropping/image_cropping.js
@@ -54,11 +54,11 @@ var image_cropping = (function ($) {
         if ($this.data('ratio')) {
           options['aspectRatio'] = $this.data('ratio');
         }
-        if ($this.data('box_max_width')) {
-          options['boxWidth'] = $this.data('box_max_width');
+        if ($this.data('box-max-width')) {
+          options['boxWidth'] = $this.data('box-max-width');
         }
-        if ($this.data('box_max_height')) {
-          options['boxHeight'] = $this.data('box_max_height');
+        if ($this.data('box-max-height')) {
+          options['boxHeight'] = $this.data('box-max-height');
         }
 
         var cropping_disabled = false;


### PR DESCRIPTION
Fix wrong word separator in `box-max-width` and `box-max-width` data attributes. In python '_' is used so it lead to a missprint. '-' is chosen for consistency with rest of frontend.
Without this `IMAGE_CROPPING_THUMB_SIZE` option makes no effect.