### PR TITLE
Fix admin widget in django 3.0

### DIFF
--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -4,7 +4,12 @@ import logging
 
 import django
 from django import forms
-from django.contrib.admin.templatetags import admin_static
+try:
+    from django.contrib.admin.templatetags import admin_static
+except ImportError:
+    class admin_static:
+        def static(path):
+            return path
 from django.contrib.admin.widgets import AdminFileWidget, ForeignKeyRawIdWidget
 from django.db.models import ObjectDoesNotExist
 


### PR DESCRIPTION
This is a small patch in order to allow using the admin widget with django 3.0. The intention was to change as little as possible while keeping backward compatibility.