### PR TITLE
Django 4.x Support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 branch = True
-include = example/*
+include =
+    example/*
+    image_cropping/*
 omit =
     */migrations/*
     */conf/*

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,12 +1,12 @@
 -e .
-easy_thumbnails==2.7.0
+easy_thumbnails==2.8.1
 WebTest==3.0.0
-django-webtest==1.9.7
+django-webtest==1.9.9
 coverage==6.3
 isort==5.10.1
 pytest==6.2.5
 pytest-cov==3.0.0
-pytest-django==3.10.0
+pytest-django==4.5.2
 pytest-env==0.6.2
 pytest-factoryboy==2.1.0
 pytest-html==3.1.1

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,14 +1,14 @@
 -e .
 easy_thumbnails==2.7.0
-WebTest==2.0.35
+WebTest==3.0.0
 django-webtest==1.9.7
-coverage==5.3
-isort==5.5.3
-pytest==6.0.2
-pytest-cov==2.10.1
+coverage==6.3
+isort==5.10.1
+pytest==6.2.5
+pytest-cov==3.0.0
 pytest-django==3.10.0
 pytest-env==0.6.2
-pytest-factoryboy==2.0.3
-pytest-html==2.1.1
-pytest-isort==1.2.0
-pytest-black==0.3.11
+pytest-factoryboy==2.1.0
+pytest-html==3.1.1
+pytest-isort==2.0.0
+pytest-black==0.3.12

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -2,7 +2,7 @@
 easy_thumbnails==2.8.1
 WebTest==3.0.0
 django-webtest==1.9.9
-coverage==6.3
+coverage==5.5
 isort==5.10.1
 pytest==6.2.5
 pytest-cov==3.0.0

--- a/example/settings.py
+++ b/example/settings.py
@@ -4,8 +4,6 @@ import sys
 
 from easy_thumbnails.conf import settings as thumbnail_settings
 
-import django.template
-
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 DEBUG = True
@@ -18,6 +16,8 @@ DATABASES = {
 }
 
 TIME_ZONE = "Europe/Berlin"
+# Keep pre Django 4.0 behaviour after upgrading
+USE_TZ = False
 LANGUAGE_CODE = "en-us"
 
 SITE_ID = 1

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,33 +1,34 @@
 from example import views
 
 from django.conf import settings
-from django.conf.urls import static, url
+from django.conf.urls import static
+from django.urls import re_path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r"^$", views.thumbnail_options, name="thumbnail_options"),
-    url(
+    re_path(r"^$", views.thumbnail_options, name="thumbnail_options"),
+    re_path(
         r"^show_foreignkey_thumbnail/$",
         views.thumbnail_foreign_key,
         name="thumbnail_foreign_key",
     ),
-    url(
+    re_path(
         r"^show_foreignkey_thumbnail/(?P<instance_id>\d+)/$",
         views.thumbnail_foreign_key,
         name="thumbnail_foreign_key",
     ),
-    url(
+    re_path(
         r"^modelform_example/(?P<image_id>\d+)/$",
         views.modelform_example,
         name="modelform_example",
     ),
-    url(r"^modelform_example/$", views.modelform_example, name="modelform_example"),
-    url(
+    re_path(r"^modelform_example/$", views.modelform_example, name="modelform_example"),
+    re_path(
         r"^show_thumbnail/(?P<image_id>\d+)/$",
         views.show_thumbnail,
         name="show_thumbnail",
     ),
-    url(r"^admin/", admin.site.urls),
+    re_path(r"^admin/", admin.site.urls),
 ]
 
 urlpatterns += static.static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/example/urls.py
+++ b/example/urls.py
@@ -2,8 +2,8 @@ from example import views
 
 from django.conf import settings
 from django.conf.urls import static
-from django.urls import re_path
 from django.contrib import admin
+from django.urls import re_path
 
 urlpatterns = [
     re_path(r"^$", views.thumbnail_options, name="thumbnail_options"),

--- a/image_cropping/backends/base.py
+++ b/image_cropping/backends/base.py
@@ -1,6 +1,6 @@
 import abc
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .. import widgets
 

--- a/image_cropping/utils.py
+++ b/image_cropping/utils.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .config import settings
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=example.settings
 addopts = --durations=10 --isort --black --durations=10 --reuse-db --cov-config .coveragerc --html test_results.html
-testpaths = example/tests
+testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,15 @@
 
 [tox]
 envlist =
-    py{37,38,39}-django22
-    py{37,38,39}-django30
-    py{37,38,39}-django31
-    py{37,38,39}-django32
+    py{36,37,38,39}-django22
+    py{36,37,38,39}-django30
+    py{36,37,38,39}-django31
+    py{36,37,38,39}-django32
     py{38,39}-django40
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -5,18 +5,18 @@
 
 [tox]
 envlist =
-    py{36,37,38,39,310}-django22
-    py{36,37,38,39,310}-django30
-    py{36,37,38,39,310}-django31
-    py{36,37,38,39,310}-django32
-    py{38,39,310}-django40
+    py{36,37,38,39}-django22
+    py{36,37,38,39}-django30
+    py{36,37,38,39}-django31
+    py{36,37,38,39}-django32
+    py{38,39}-django40
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32
-    py{38,39}-django32
+    py{38,39}-django40
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -5,29 +5,27 @@
 
 [tox]
 envlist =
-    py{36,37,38,39}-django22
-    py{36,37,38,39}-django30
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
-    py{38,39}-django40
+    py{36,37,38,39,310}-django22
+    py{36,37,38,39,310}-django30
+    py{36,37,38,39,310}-django31
+    py{36,37,38,39,310}-django32
+    py{38,39,310}-django40
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands =
-    pytest example --create-db --cache-clear --cov-append
-;   # TODO: fixme it is empty and thus failing
-;    coverage report
+    coverage run -m pytest example --create-db --cache-clear --cov-append
+    coverage report
 setenv =
     DJANGO_SETTINGS_MODULE=example.settings
     PYTHONPATH={toxinidir}
 deps =
-    pillow==6.2.2
     -r{toxinidir}/example/requirements.txt
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32
+    py{38,39}-django32
 
 [gh-actions]
 python =
@@ -32,3 +33,4 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4
+    django40: Django>=4.0,<4.1


### PR DESCRIPTION
This PR fixes #173 and updates to Django 4.0.

Things that have been changed:
- Requirements updated to latest
- ugettext (replaced by gettext)
- url (replaced by re_path)
- USE_TZ (was set to False as the default values has been changes to True in D4.0. False keeps the <4.0 behaviour.)

I've added a new tox env from Django 4.0 with Python 3.8 + 3.9 as previous versions are not supported anymore.

tox reports:

```
ERROR:  py36-django22: InterpreterNotFound: python3.6
ERROR:  py37-django22: InterpreterNotFound: python3.7
  py38-django22: commands succeeded
ERROR:   py39-django22: could not install deps [pillow==6.2.2, -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt, Django>=2.2,<3.0]; v = InvocationError("/Users/janwedel/Development/repos/django-image-cropping/.tox/py39-django22/bin/python -m pip install pillow==6.2.2 -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt 'Django>=2.2,<3.0'", 1)
ERROR:  py36-django30: InterpreterNotFound: python3.6
ERROR:  py37-django30: InterpreterNotFound: python3.7
  py38-django30: commands succeeded
ERROR:   py39-django30: could not install deps [pillow==6.2.2, -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt, Django>=3.0,<3.1]; v = InvocationError("/Users/janwedel/Development/repos/django-image-cropping/.tox/py39-django30/bin/python -m pip install pillow==6.2.2 -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt 'Django>=3.0,<3.1'", 1)
ERROR:  py36-django31: InterpreterNotFound: python3.6
ERROR:  py37-django31: InterpreterNotFound: python3.7
  py38-django31: commands succeeded
ERROR:   py39-django31: could not install deps [pillow==6.2.2, -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt, Django>=3.1,<3.2]; v = InvocationError("/Users/janwedel/Development/repos/django-image-cropping/.tox/py39-django31/bin/python -m pip install pillow==6.2.2 -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt 'Django>=3.1,<3.2'", 1)
ERROR:  py36-django32: InterpreterNotFound: python3.6
ERROR:  py37-django32: InterpreterNotFound: python3.7
  py38-django32: commands succeeded
ERROR:   py39-django32: could not install deps [pillow==6.2.2, -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt, Django>=3.2,<4]; v = InvocationError("/Users/janwedel/Development/repos/django-image-cropping/.tox/py39-django32/bin/python -m pip install pillow==6.2.2 -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt 'Django>=3.2,<4'", 1)
  py38-django40: commands succeeded
ERROR:   py39-django40: could not install deps [pillow==6.2.2, -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt, Django>=4.0,<4.1]; v = InvocationError("/Users/janwedel/Development/repos/django-image-cropping/.tox/py39-django40/bin/python -m pip install pillow==6.2.2 -r/Users/janwedel/Development/repos/django-image-cropping/example/requirements.txt 'Django>=4.0,<4.1'", 1)
```

I don't have all python versions installed, but surprisingly, the tests actually work even on Django 2.2. Didn't expect that.

I also change the purest config as it was pointing to a non existing tests directory. Not sure if this was intentional or not.