### PR TITLE
Fix Github Workflow

### DIFF
--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -32,7 +32,7 @@ jobs:
         isort .
         black .
     - name: Report to coverall  # by the package as the action is broken, but won't work on external forks!
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == 3.7 && github.repository == 'jonasundderwolf/django-image-cropping'
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-easy_thumbnails==2.8.1
+easy_thumbnails==2.9
 WebTest==3.0.0
 django-webtest==1.9.9
 coverage==5.5

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-easy_thumbnails==2.9
+easy_thumbnails==2.8.5
 WebTest==3.0.0
 django-webtest==1.9.9
 coverage==5.5

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,14 @@
 
 [tox]
 envlist =
-    py{36,37,38,39}-django22
-    py{36,37,38,39}-django30
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
+    py{37,38,39}-django22
+    py{37,38,39}-django30
+    py{37,38,39}-django31
+    py{37,38,39}-django32
     py{38,39}-django40
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,15 @@ envlist =
     py{37,38,39}-django22
     py{37,38,39}-django30
     py{37,38,39}-django31
-    py{37,38,39}-django32
-    py{38,39}-django40
+    py{37,38,39,310}-django32
+    py{38,39,310}-django40
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.6 is not available any more in the workflow runner, so I removed it and added Python 3.10 instead. Also, I upgraded easy_thumbnails to 3.8.5 in the example project, as this is necessary to support Pillow 10.0 and later (removal of `Image.ANTIALIAS`). Finally, added a condition so the coverall action does not get executed in forks (it will fail due to missing token).