### PR TITLE
Handle DecompressionBombError when uploading a large image

### DIFF
--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -32,7 +32,7 @@ jobs:
         isort .
         black .
     - name: Report to coverall  # by the package as the action is broken, but won't work on external forks!
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == 3.7 && github.repository == 'jonasundderwolf/django-image-cropping'
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-easy_thumbnails==2.8.1
+easy_thumbnails==2.9
 WebTest==3.0.0
 django-webtest==1.9.9
 coverage==5.5

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-easy_thumbnails==2.9
+easy_thumbnails==2.8.5
 WebTest==3.0.0
 django-webtest==1.9.9
 coverage==5.5

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -38,8 +38,9 @@ def get_attrs(image, name):
         try:
             # open image and rotate according to its exif.orientation
             width, height = get_backend().get_size(image)
-        except AttributeError:
-            # invalid image -> AttributeError
+        except BaseException:
+            # invalid image -> AttributeError or DecompressionBombError
+            logger.warning("Error while getting image size", exc_info=True)
             width = image.width
             height = image.height
         return {

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,14 @@
 
 [tox]
 envlist =
-    py{36,37,38,39}-django22
-    py{36,37,38,39}-django30
-    py{36,37,38,39}-django31
-    py{36,37,38,39}-django32
+    py{37,38,39}-django22
+    py{37,38,39}-django30
+    py{37,38,39}-django31
+    py{37,38,39}-django32
     py{38,39}-django40
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,15 @@ envlist =
     py{37,38,39}-django22
     py{37,38,39}-django30
     py{37,38,39}-django31
-    py{37,38,39}-django32
-    py{38,39}-django40
+    py{37,38,39,310}-django32
+    py{38,39,310}-django40
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands =


### PR DESCRIPTION
# Steps to reproduce

1. run the example project
2. try to upload a large image ([for example this 16000x16000 gif](https://github.com/user-attachments/assets/7cc1604c-84c0-461c-a938-74af18710769)) using ModelForm

# Expected result

The form should be invalid and user should be notified of error (invalid file)

# Actual result

Since Pillow throws a `DecompressionBombError` instead of an `AttributeError`, this won't be caught in `get_attrs()` when trying to determine the image size. The view returns an error 500 instead of showing the invalid form. The user has no chance to see what's going wrong.

# Solution

When rendering the widget, any exception from the backend should be handled. This is what this PR does.

# Notes

This PR is based on my other PR (#184), in order to let the workflow/automated test run.


