### PR TITLE
Fix: Handle missing files in MinIO storage by catching Exception in get_attrs

### DIFF
--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -40,8 +40,12 @@ def get_attrs(image, name):
             width, height = get_backend().get_size(image)
         except AttributeError:
             # invalid image -> AttributeError
-            width = image.width
-            height = image.height
+            try:
+                width = image.width
+                height = image.height
+            except:
+                width = None
+                height = None
         return {
             "class": "crop-thumb",
             "data-thumbnail-url": thumbnail_url(image),

--- a/image_cropping/widgets.py
+++ b/image_cropping/widgets.py
@@ -46,6 +46,10 @@ def get_attrs(image, name):
             except:
                 width = None
                 height = None
+        except Exception as e:
+            logger.error(e.__str__())
+            width = None
+            height = None
         return {
             "class": "crop-thumb",
             "data-thumbnail-url": thumbnail_url(image),


### PR DESCRIPTION
## Problem
When using MinIO/S3 storage, if an image file is deleted from storage, 
the admin interface crashes with `NoSuchKey` exception because 
`get_attrs()` doesn't handle missing files properly.

## Solution  
Add Exception handling in `get_attrs()` function to catch cases when 
image file doesn't exist in storage.

## Changes
- Modified `image_cropping/widgets.py`
- Added try/except block around `image.width` and `image.height` access